### PR TITLE
fix: reorder dataframe by XY if needed

### DIFF
--- a/R/mapiso.R
+++ b/R/mapiso.R
@@ -150,6 +150,9 @@ mapiso <- function(x, var, breaks, nbreaks = 8, mask, coords, crs) {
       )
     }
 
+    # Reorder dataframe by X-Y if needed
+    x <- x[with(x, order(Y, X)),]
+    
     m <- t(
       matrix(
         data = x[[var]],

--- a/R/mapiso.R
+++ b/R/mapiso.R
@@ -130,6 +130,9 @@ mapiso <- function(x, var, breaks, nbreaks = 8, mask, coords, crs) {
     x <- data.frame(st_coordinates(x), var = x[[var]])
     coords <- c("X", "Y")
     var <- "var"
+    # Reorder dataframe by X-Y if needed
+    x <- x[with(x, order(Y, X)),]
+    
   }
 
 
@@ -150,8 +153,6 @@ mapiso <- function(x, var, breaks, nbreaks = 8, mask, coords, crs) {
       )
     }
 
-    # Reorder dataframe by X-Y if needed
-    x <- x[with(x, order(Y, X)),]
     
     m <- t(
       matrix(


### PR DESCRIPTION
In case of point layer with X/Y coordinates not sorted (strange, but can happen !), the mapiso function fails (see reproducible example). This update proposal in the mapiso function fixes the problem. 
[iso_stuff.zip](https://github.com/riatelab/mapiso/files/9504050/iso_stuff.zip)
